### PR TITLE
Add alt text via media descriptions

### DIFF
--- a/src/components/Yii2CloudinaryComponent.php
+++ b/src/components/Yii2CloudinaryComponent.php
@@ -357,13 +357,30 @@ class Yii2CloudinaryComponent extends Component
         $defaultTransform = implode(',', array_merge($baseTransform, ["w_{$maxWidth}"]));
         $defaultSrc = "{$base}/{$defaultTransform}/{$media->public_id}{$formatSuffix}";
 
+        $sizes = $htmlOptions['sizes'] ?? '(min-width: 768px) 33vw, 100vw';
+
+        $altText = '';
+        foreach ($media->descriptions as $desc) {
+            if ($desc->lang === Yii::$app->language && !empty($desc->description)) {
+                $altText = $desc->description;
+                break;
+            }
+        }
+        if ($altText === '') {
+            foreach ($media->descriptions as $desc) {
+                if (!empty($desc->description)) {
+                    $altText = $desc->description;
+                    break;
+                }
+            }
+        }
+
         $attrs = array_merge([
             'src' => $defaultSrc,
             'srcset' => implode(', ', $srcset),
-            'sizes' => $htmlOptions['sizes'] ?? '(min-width: 768px) 33vw, 100vw',
             'width' => $meta->width,
             'height' => $meta->height,
-            'alt' => $media->alt ?? '',
+            'alt' => $altText,
             'loading' => 'lazy',
         ], $htmlOptions);
 
@@ -375,7 +392,7 @@ class Yii2CloudinaryComponent extends Component
             $attrString .= " {$key}=\"{$escaped}\"";
         }
 
-        return "<img{$attrString} sizes=\"(min-width: 768px) 33vw, 100vw\">";
+        return "<img{$attrString} sizes=\"{$sizes}\">";
     }
 
 


### PR DESCRIPTION
## Summary
- derive `alt` from `CloudinaryMediaDesc` instead of image meta
- remove unused migration and model `alt` field
- keep responsive image sizing override support

## Testing
- `php -l src/models/CloudinaryImageMeta.php` *(fails: command not found)*
- `php -l src/components/Yii2CloudinaryComponent.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0208a304832899b42c5f95f00bb5